### PR TITLE
Use a single worker for Alfred

### DIFF
--- a/alfred/entrypoint.sh
+++ b/alfred/entrypoint.sh
@@ -1,2 +1,2 @@
 sudo service olad start
-uwsgi --http-socket 0.0.0.0:5000 -p 4 --manage-script-name --master --no-orphans --mount /=alfred_http.flask.entry_point:app --pyargv alfred_maison.extension.MaisonExtension
+uwsgi --http-socket 0.0.0.0:5000 -p 1 --manage-script-name --master --no-orphans --mount /=alfred_http.flask.entry_point:app --pyargv alfred_maison.extension.MaisonExtension


### PR DESCRIPTION
Use a single worker for Alfred to prevent running into memory storage synchronization bugs.

A long-term solution will be developed in https://github.com/bartfeenstra/alfred/issues/43.